### PR TITLE
ci: add Dependabot for GitHub Actions and Go modules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 2026-03-16
 
 ### Features
-- add Homebrew tap support for installation (076edb6)
+- Homebrew tap for brew install tq-lang/tap/tq (#9) (05eb11d)
 
 ## 2026-03-13
 


### PR DESCRIPTION
## Summary

- Add Dependabot configuration for weekly updates of GitHub Actions and Go modules

Closes #11

## Test plan

- [x] Valid YAML syntax
- [ ] Verify Dependabot picks up the config after merge (check Security → Dependabot tab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds Dependabot config and a small changelog edit, with no runtime code changes.
> 
> **Overview**
> Adds Dependabot configuration to run **weekly** updates for `github-actions` and `gomod` dependencies.
> 
> Updates `CHANGELOG.md` to record the Homebrew tap feature entry for the 2026-03-16 release.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9cc6c51ef93cccd65381b82a318fa6671b23cf2a. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->