### PR TITLE
feat(cli): grouped help, --quiet flag, and help improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,13 @@
 ## 2026-03-17
 
 ### Features
-- native TOON streaming with auto-detection and filter warnings (a40c2f8)
+- native TOON streaming with auto-detection and filter warnings (#18) (528b8e5)
+
+### Build
+- bump actions/checkout from 4 to 6 (#15) (41d47be)
+- bump actions/setup-go from 5 to 6 (#13) (b857102)
+- bump golangci/golangci-lint-action from 6 to 9 (#16) (a06d964)
+- bump goreleaser/goreleaser-action from 6 to 7 (#14) (84c9fd7)
 
 ## 2026-03-16
 
@@ -12,7 +18,6 @@
 
 ### CI
 - add Dependabot for GitHub Actions and Go modules (#12) (1e5acd6)
-- add Dependabot for GitHub Actions and Go modules (9cc6c51)
 
 ## 2026-03-13
 

--- a/cmd/tq/main.go
+++ b/cmd/tq/main.go
@@ -48,6 +48,7 @@ type config struct {
 	stream          bool
 	noStream        bool
 	streamThreshold string
+	quiet           bool
 	delimiter       string
 	fromFile        string
 	version         bool
@@ -58,45 +59,80 @@ type config struct {
 func parseFlags() (*config, []string) {
 	cfg := &config{}
 
-	flag.BoolVar(&cfg.jsonOutput, "json", false, "output JSON instead of TOON")
-	flag.BoolVar(&cfg.toonOutput, "toon", false, "output TOON (default)")
-	flag.BoolVarP(&cfg.rawOutput, "raw-output", "r", false, "output raw strings")
-	flag.BoolVarP(&cfg.compact, "compact-output", "c", false, "compact output")
-	flag.BoolVarP(&cfg.slurp, "slurp", "s", false, "read entire input into array")
-	flag.BoolVarP(&cfg.nullInput, "null-input", "n", false, "run filter without reading input")
-	flag.BoolVarP(&cfg.joinOutput, "join-output", "j", false, "no newline between outputs")
-	flag.BoolVar(&cfg.tab, "tab", false, "use tab for indentation")
-	flag.IntVar(&cfg.indent, "indent", 0, "number of spaces for indentation")
-	flag.BoolVarP(&cfg.exitStatus, "exit-status", "e", false, "set exit code based on output")
-	flag.BoolVar(&cfg.stream, "stream", false, "output path-value pairs for streaming")
-	flag.BoolVar(&cfg.noStream, "no-stream", false, "disable auto-streaming for large files")
-	flag.StringVar(&cfg.streamThreshold, "stream-threshold", "", "auto-stream file size threshold (e.g. 256MB, 1GB)")
-	flag.StringVar(&cfg.delimiter, "delimiter", "", "TOON output delimiter: comma, tab, pipe")
-	flag.StringVarP(&cfg.fromFile, "from-file", "f", "", "read filter from file")
-	flag.BoolVar(&cfg.version, "version", false, "print version")
-	flag.StringArrayVar(&cfg.argPairs, "arg", nil, "set variable: --arg name value")
-	flag.StringArrayVar(&cfg.argjsonPairs, "argjson", nil, "set JSON variable: --argjson name value")
+	flag.BoolVar(&cfg.jsonOutput, "json", false, "")
+	flag.BoolVar(&cfg.toonOutput, "toon", false, "")
+	flag.BoolVarP(&cfg.rawOutput, "raw-output", "r", false, "")
+	flag.BoolVarP(&cfg.compact, "compact-output", "c", false, "")
+	flag.BoolVarP(&cfg.joinOutput, "join-output", "j", false, "")
+	flag.BoolVar(&cfg.tab, "tab", false, "")
+	flag.IntVar(&cfg.indent, "indent", 0, "")
+	flag.StringVar(&cfg.delimiter, "delimiter", "", "")
+	flag.BoolVarP(&cfg.slurp, "slurp", "s", false, "")
+	flag.BoolVarP(&cfg.nullInput, "null-input", "n", false, "")
+	flag.StringVarP(&cfg.fromFile, "from-file", "f", "", "")
+	flag.StringArrayVar(&cfg.argPairs, "arg", nil, "")
+	flag.StringArrayVar(&cfg.argjsonPairs, "argjson", nil, "")
+	flag.BoolVar(&cfg.stream, "stream", false, "")
+	flag.BoolVar(&cfg.noStream, "no-stream", false, "")
+	flag.StringVar(&cfg.streamThreshold, "stream-threshold", "", "")
+	flag.BoolVarP(&cfg.exitStatus, "exit-status", "e", false, "")
+	flag.BoolVarP(&cfg.quiet, "quiet", "q", false, "")
+	flag.BoolVar(&cfg.version, "version", false, "")
 
-	flag.Usage = func() {
-		fmt.Fprint(os.Stderr, `Usage: tq [flags] <filter> [file...]
+	flag.Usage = printUsage
+
+	flag.Parse()
+	return cfg, flag.Args()
+}
+
+func printUsage() {
+	fmt.Fprint(os.Stderr, `Usage: tq [flags] <filter> [file...]
 
 tq is a command-line TOON/JSON processor. Like jq, but for TOON.
 
 Examples:
-  echo '{"name":"Alice"}' | tq '.name'          # field access
-  echo '{"a":1}' | tq --json '.'                # convert to JSON
-  cat data.toon | tq '.users[] | .name'          # iterate array
-  tq -n '1 + 1'                                  # null input
-  tq '.key' file1.json file2.toon                # read from files
-  echo '{"a":1}' | tq '.' -                      # explicit stdin
+  echo '{"name":"Alice"}' | tq '.name'           # field access
+  echo '{"a":1}' | tq --json '.'                 # convert to JSON
+  cat data.toon | tq '.users[] | .name'           # iterate array
+  tq -n '1 + 1'                                   # null input
+  tq '.key' file1.json file2.toon                 # multiple files
+  echo '[1,2,3]' | tq -s 'add'                    # slurp + reduce
+  tq -f filter.jq data.json                       # filter from file
+  tq --stream --json -c '.' large.toon            # stream large files
 
-Flags:
+Output flags:
+      --json                   output JSON instead of TOON
+      --toon                   output TOON (default)
+  -r, --raw-output             output raw strings without quotes
+  -c, --compact-output         compact single-line output
+  -j, --join-output            no newline between output values
+      --tab                    indent with tabs
+      --indent N               indent with N spaces (default 2)
+      --delimiter TYPE         TOON array delimiter: comma, tab, pipe
+
+Input flags:
+  -s, --slurp                  read all inputs into an array
+  -n, --null-input             run filter with null input
+  -f, --from-file PATH         read filter from file
+      --arg NAME VALUE         bind $NAME to string VALUE
+      --argjson NAME VALUE     bind $NAME to parsed JSON VALUE
+
+Streaming flags:
+      --stream                 emit [path, value] pairs (O(depth) memory)
+      --no-stream              disable auto-streaming for large files
+      --stream-threshold SIZE  auto-stream file size (default 256MB)
+
+Other flags:
+  -e, --exit-status            exit 4 if filter produces no output
+  -q, --quiet                  suppress info and warning messages
+      --version                print version and exit
+  -h, --help                   show this help
+
+Environment:
+  TQ_STREAM_THRESHOLD          auto-stream threshold (e.g. 512MB, 1GB)
+
+Documentation: https://github.com/tq-lang/tq
 `)
-		flag.PrintDefaults()
-	}
-
-	flag.Parse()
-	return cfg, flag.Args()
 }
 
 // resolveFilter determines the jq filter expression and remaining file args.
@@ -220,7 +256,9 @@ func run() int {
 		if src != 0 {
 			return src
 		}
-		warnNonStreamable(filterExpr)
+		if !cfg.quiet {
+			warnNonStreamable(filterExpr)
+		}
 	}
 
 	threshold := resolveStreamThreshold(cfg)
@@ -298,8 +336,10 @@ func processFiles(files []string, code *gojq.Code, varValues []any, opts output.
 			if src != 0 {
 				return src
 			}
-			fmt.Fprintf(os.Stderr, "tq: info: streaming enabled for %s (file > %s)\n", fileLabel(f), formatSize(threshold))
-			warnNonStreamable(filterExpr)
+			if !cfg.quiet {
+				fmt.Fprintf(os.Stderr, "tq: info: streaming enabled for %s (file > %s)\n", fileLabel(f), formatSize(threshold))
+				warnNonStreamable(filterExpr)
+			}
 		}
 		rc := filterFile(f, code, varValues, opts, hasOutput, fileSC)
 		if rc == exitUsage {

--- a/cmd/tq/main_test.go
+++ b/cmd/tq/main_test.go
@@ -150,6 +150,14 @@ func TestCLI(t *testing.T) {
 		{"stream sort warning", `{}`, []string{"--stream", "--json", "-c", "select(false) | sort"}, 0, "", "warning: 'sort'"},
 		{"stream sort_by warning", `{}`, []string{"--stream", "--json", "-c", "select(false) | sort_by(.x)"}, 0, "", "warning: 'sort_by'"},
 
+		// Quiet mode
+		{"quiet suppresses warning", `{}`, []string{"--stream", "--quiet", "--json", "-c", "select(false) | sort"}, 0, "", ""},
+
+		// Help output
+		{"help shows groups", "", []string{"--help"}, 0, "", "Output flags:"},
+		{"help shows env", "", []string{"--help"}, 0, "", "TQ_STREAM_THRESHOLD"},
+		{"help shows docs link", "", []string{"--help"}, 0, "", "github.com/tq-lang/tq"},
+
 		// Errors
 		{"invalid filter", `{}`, []string{".[invalid|||"}, 3, "", "parse error"},
 		{"runtime error", `42`, []string{".foo"}, 5, "", "expected an object"},
@@ -287,6 +295,20 @@ func TestCLIWithFiles(t *testing.T) {
 		}
 		if !strings.Contains(errBuf.String(), "streaming enabled") {
 			t.Errorf("expected auto-stream via env var, got stderr %q", errBuf.String())
+		}
+	})
+
+	t.Run("quiet suppresses auto-stream info", func(t *testing.T) {
+		f := filepath.Join(tmp, "small4.json")
+		if err := os.WriteFile(f, []byte(`{"a":1}`), 0644); err != nil {
+			t.Fatal(err)
+		}
+		_, stderr, code := runTQ(t, "", "--quiet", "--stream-threshold", "1B", "--json", "-c", ".", f)
+		if code != 0 {
+			t.Fatalf("exit code = %d, want 0", code)
+		}
+		if strings.Contains(stderr, "streaming enabled") {
+			t.Errorf("--quiet should suppress auto-stream info, got stderr %q", stderr)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

Implements all actionable items from the CLI guidelines audit (#17).

- **Grouped help output** — flags organized into Output, Input, Streaming, Other sections instead of a flat alphabetical list
- **`-q/--quiet` flag** — suppresses info messages (auto-stream notifications) and warnings (non-streamable filter builtins) on stderr
- **New examples in help** — added `slurp + reduce` and `filter from file` examples
- **Environment variable in help** — `TQ_STREAM_THRESHOLD` now shown in help output
- **Documentation link** — footer links to `https://github.com/tq-lang/tq`
- **Verified** `-h` and `--` both work correctly (pflag handles them)

## Before / After

<details>
<summary>Before (flat list, 19 flags)</summary>

```
Flags:
      --arg stringArray           set variable: --arg name value
      --argjson stringArray       set JSON variable: --argjson name value
  -c, --compact-output            compact output
      --delimiter string          TOON output delimiter: comma, tab, pipe
  ...19 more unsorted flags...
```
</details>

<details>
<summary>After (grouped, 20 flags)</summary>

```
Output flags:
      --json                   output JSON instead of TOON
      --toon                   output TOON (default)
  -r, --raw-output             output raw strings without quotes
  ...

Input flags:
  -s, --slurp                  read all inputs into an array
  ...

Streaming flags:
      --stream                 emit [path, value] pairs (O(depth) memory)
  ...

Other flags:
  -q, --quiet                  suppress info and warning messages
  ...

Environment:
  TQ_STREAM_THRESHOLD          auto-stream threshold (e.g. 512MB, 1GB)

Documentation: https://github.com/tq-lang/tq
```
</details>

## Test plan

- [x] `--quiet` suppresses stream warnings (stdin test)
- [x] `--quiet` suppresses auto-stream info messages (file test)
- [x] Help output contains grouped sections
- [x] Help output shows `TQ_STREAM_THRESHOLD`
- [x] Help output shows docs link
- [x] All existing tests pass
- [x] golangci-lint clean

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)