### PR TITLE
fix(ci): stop PR churn by auto-syncing changelog on main

### DIFF
--- a/.github/workflows/changelog-sync.yml
+++ b/.github/workflows/changelog-sync.yml
@@ -1,0 +1,32 @@
+name: Changelog Sync
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  sync-changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: Regenerate changelog
+        run: bash scripts/generate-changelog.sh
+
+      - name: Commit changelog update when needed
+        run: |
+          if git diff --quiet -- CHANGELOG.md; then
+            echo "CHANGELOG.md already up to date."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md
+          git commit -m "chore(changelog): sync changelog on main"
+          git push

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,15 +24,6 @@ jobs:
       - name: Build
         run: go build ./cmd/tq
 
-      - name: Verify changelog is up to date
-        if: github.event_name == 'pull_request'
-        run: |
-          bash scripts/generate-changelog.sh
-          if ! git diff --exit-code -- CHANGELOG.md; then
-            echo "CHANGELOG.md is stale. Run: make generate-changelog"
-            exit 1
-          fi
-
       - name: Vet
         run: go vet ./...
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 2026-03-17
 
 ### Features
-- add SBOM publishing and provenance attestations (51605e3)
+- add SBOM + provenance attestations (#27) (6addb9e)
 - grouped help, --quiet flag, env/docs in help output (#19) (2947185)
 - native TOON streaming with auto-detection and filter warnings (#18) (528b8e5)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,10 @@ make check
 
 ### Changelog Workflow
 
-`CHANGELOG.md` is enforced in CI on pull requests. Generate it locally before opening or updating a PR:
+`CHANGELOG.md` is generated from commit history and synced automatically on pushes to `main`.
+PR checks do not fail on changelog drift anymore, and contributors do not need to refresh `CHANGELOG.md` per PR.
+
+If you want to preview the generated changelog locally:
 
 ```bash
 make generate-changelog


### PR DESCRIPTION
## Problem
PRs repeatedly fail on stale changelog checks because the latest commit cannot include its own changelog entry in the same commit.

## Solution
- remove PR stale-changelog gate from CI
- add a dedicated Changelog Sync workflow on push to main that regenerates and commits CHANGELOG.md only when needed
- document the new CI-native workflow in CONTRIBUTING

## Trade-off
- changelog freshness is enforced on main post-merge (not as a PR blocker), which removes recursive PR failures and keeps changelog commit-history based

## Validation
- go test ./...