### PR TITLE
ci: use GitHub App token for homebrew tap updates

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+CHANGELOG.md merge=union

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,13 +22,22 @@ jobs:
         with:
           go-version: "1.24"
 
+      - name: Create Homebrew tap app token
+        id: homebrew_tap_app_token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        with:
+          app-id: ${{ secrets.HOMEBREW_TAP_APP_ID }}
+          private-key: ${{ secrets.HOMEBREW_TAP_APP_PRIVATE_KEY }}
+          owner: tq-lang
+          repositories: homebrew-tap
+
       - uses: goreleaser/goreleaser-action@9a127d869fb706213d29cdf8eef3a4ea2b869415 # v7
         with:
           version: "~> v2"
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ steps.homebrew_tap_app_token.outputs.token }}
 
       - name: Attest release archives
         uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,7 @@ make check
 
 `CHANGELOG.md` is generated from commit history and synced automatically on pushes to `main`.
 PR checks do not fail on changelog drift anymore, and contributors do not need to refresh `CHANGELOG.md` per PR.
+`CHANGELOG.md` uses a permissive merge strategy (`merge=union`) to avoid PR merge conflicts; the post-merge sync on `main` normalizes the file.
 
 If you want to preview the generated changelog locally:
 
@@ -90,17 +91,20 @@ We use [Conventional Commits](https://www.conventionalcommits.org/). Prefix your
 
 ## Release Setup
 
-Releases are automated via GoReleaser on tag push. The Homebrew formula is published to [`tq-lang/homebrew-tap`](https://github.com/tq-lang/homebrew-tap) automatically, but requires a one-time secret setup:
+Releases are automated via GoReleaser on tag push. The Homebrew formula is published to [`tq-lang/homebrew-tap`](https://github.com/tq-lang/homebrew-tap) automatically via a GitHub App installation token.
 
-1. Go to https://github.com/settings/personal-access-tokens/new
-2. Create a **fine-grained PAT** with:
-   - **Resource owner**: `tq-lang`
-   - **Repository access**: Only select `tq-lang/homebrew-tap`
-   - **Permissions**: Contents → **Read and write**
-3. Go to https://github.com/tq-lang/tq/settings/secrets/actions
-4. Add a new repository secret:
-   - **Name**: `HOMEBREW_TAP_TOKEN`
-   - **Value**: the PAT from step 2
+One-time org setup:
+
+1. Create an org-owned GitHub App (or reuse an existing org app).
+2. Grant repository permission: **Contents: Read and write**.
+3. Install the app on `tq-lang/homebrew-tap`.
+
+One-time `tq-lang/tq` repo setup:
+
+1. Go to https://github.com/tq-lang/tq/settings/secrets/actions
+2. Add repository secrets:
+   - `HOMEBREW_TAP_APP_ID` (the GitHub App ID)
+   - `HOMEBREW_TAP_APP_PRIVATE_KEY` (the full PEM private key)
 
 After this, any `v*` tag push will build binaries, create a GitHub release, and update the Homebrew formula.
 


### PR DESCRIPTION
## Summary
- replace PAT-based `HOMEBREW_TAP_TOKEN` secret usage with a short-lived GitHub App installation token in release workflow
- keep Goreleaser wiring unchanged by continuing to supply `HOMEBREW_TAP_TOKEN` env var, now sourced from app-token step output
- update release setup docs to describe GitHub App setup and required repository secrets
- reduce recurring CHANGELOG merge conflicts by adding `.gitattributes` rule for `CHANGELOG.md`

Closes #30

## Why this replacement PR
The previous PR branch had unrelated history/changelog churn. This PR is rebased cleanly on `main` and only contains the intended changes.
