### PR TITLE
fix(release): fix homebrew tap formula path and enable prerelease support

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -28,6 +28,7 @@ changelog:
 
 release:
   extra_files: []
+  prerelease: auto
   footer: |
     **Full Changelog**: https://github.com/tq-lang/tq/blob/main/CHANGELOG.md
 
@@ -37,6 +38,14 @@ brews:
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
       branch: goreleaser-{{ .ProjectName }}-{{ .Version }}
+      pull_request:
+        enabled: true
+        base:
+          owner: tq-lang
+          name: homebrew-tap
+          branch: main
+    skip_upload: false
+    directory: Formula
     homepage: https://github.com/tq-lang/tq
     description: "Command-line TOON/JSON processor — jq for TOON"
     license: MIT


### PR DESCRIPTION
## Summary
- **Formula path**: Add `directory: Formula` so the formula lands at `Formula/tq.rb` instead of the repo root — matching what the tap CI expects
- **Auto-PR to tap**: Enable `pull_request` so GoReleaser creates a PR from its branch into `main` on `homebrew-tap`, instead of leaving the formula stranded on a dead branch
- **Prerelease marking**: Add `prerelease: auto` so `-rc`/`-beta`/`-alpha` tags are correctly marked as prereleases on GitHub
- **Prerelease formula**: Set `skip_upload: false` so prereleases also push a formula, enabling homebrew testing for RC builds

## Test plan
- [ ] Push a new RC tag (e.g. `v0.1.0-rc9`) after merging
- [ ] Verify GitHub release is marked as prerelease
- [ ] Verify a PR is created in `tq-lang/homebrew-tap` with formula at `Formula/tq.rb`
- [ ] Verify tap CI passes on the PR (audit, install, smoke test)
- [ ] Merge the tap PR and run `brew install tq-lang/tap/tq` on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)