### PR TITLE
fix: address CLI audit findings

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,7 +4,7 @@ builds:
   - main: ./cmd/tq
     binary: tq
     ldflags:
-      - -s -w -X main.version={{.Version}}
+      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}}
     goos:
       - linux
       - darwin

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ VERSION ?= dev
 .PHONY: build test test-docs lint check cover clean changelog check-changelog
 
 build:
-	go build -ldflags "-X main.version=$(VERSION)" -o tq ./cmd/tq
+	go build -ldflags "-X main.version=$(VERSION) -X main.commit=$(shell git rev-parse --short HEAD) -X main.date=$(shell date -u +%Y-%m-%d)" -o tq ./cmd/tq
 
 test:
 	go test -v ./...

--- a/cmd/tq/flags.go
+++ b/cmd/tq/flags.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	flag "github.com/spf13/pflag"
 )
@@ -30,6 +31,34 @@ type config struct {
 	argjsonPairs    []string
 }
 
+// extractVarArgs scans args for --arg/--argjson NAME VALUE (jq-style two-positional-arg syntax),
+// collects the pairs, and returns the remaining args for pflag.
+func extractVarArgs(args []string) (remaining []string, argPairs, argjsonPairs []string, err error) {
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		if a == "--" {
+			remaining = append(remaining, args[i:]...)
+			break
+		}
+		if a == "--arg" || a == "--argjson" {
+			if i+2 >= len(args) {
+				return nil, nil, nil, fmt.Errorf("tq: --%s requires NAME and VALUE arguments", strings.TrimPrefix(a, "--"))
+			}
+			name := args[i+1]
+			value := args[i+2]
+			if a == "--arg" {
+				argPairs = append(argPairs, name, value)
+			} else {
+				argjsonPairs = append(argjsonPairs, name, value)
+			}
+			i += 2
+			continue
+		}
+		remaining = append(remaining, a)
+	}
+	return remaining, argPairs, argjsonPairs, nil
+}
+
 func parseFlags() (*config, []string) {
 	cfg := &config{}
 
@@ -44,8 +73,6 @@ func parseFlags() (*config, []string) {
 	flag.BoolVarP(&cfg.slurp, "slurp", "s", false, "")
 	flag.BoolVarP(&cfg.nullInput, "null-input", "n", false, "")
 	flag.StringVarP(&cfg.fromFile, "from-file", "f", "", "")
-	flag.StringArrayVar(&cfg.argPairs, "arg", nil, "")
-	flag.StringArrayVar(&cfg.argjsonPairs, "argjson", nil, "")
 	flag.BoolVar(&cfg.stream, "stream", false, "")
 	flag.BoolVar(&cfg.noStream, "no-stream", false, "")
 	flag.StringVar(&cfg.streamThreshold, "stream-threshold", "", "")
@@ -55,24 +82,33 @@ func parseFlags() (*config, []string) {
 
 	flag.Usage = printUsage
 
-	flag.Parse()
+	// Extract --arg/--argjson before pflag parsing (jq-style two-arg syntax).
+	remaining, argPairs, argjsonPairs, err := extractVarArgs(os.Args[1:])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(exitUsage)
+	}
+	cfg.argPairs = argPairs
+	cfg.argjsonPairs = argjsonPairs
+
+	flag.CommandLine.Parse(remaining)
 	return cfg, flag.Args()
 }
 
 func printUsage() {
-	fmt.Fprint(os.Stderr, `Usage: tq [flags] <filter> [file...]
+	fmt.Fprint(os.Stdout, `Usage: tq [flags] <filter> [file...]
 
 tq is a command-line TOON/JSON processor. Like jq, but for TOON.
 
 Examples:
-  echo '{"name":"Alice"}' | tq '.name'           # field access
-  echo '{"a":1}' | tq --json '.'                 # convert to JSON
-  cat data.toon | tq '.users[] | .name'           # iterate array
-  tq -n '1 + 1'                                   # null input
-  tq '.key' file1.json file2.toon                 # multiple files
-  echo '[1,2,3]' | tq -s 'add'                    # slurp + reduce
-  tq -f filter.jq data.json                       # filter from file
-  tq --stream --json -c '.' large.toon            # stream large files
+  echo 'name Alice' | tq '.name'                  # field access
+  echo 'a 1' | tq --json '.'                      # convert to JSON
+  cat data.toon | tq '.users[] | .name'            # iterate array
+  tq -n '1 + 1'                                    # null input
+  tq '.key' file1.json file2.toon                  # multiple files
+  echo '1 2 3' | tq -s 'add'                       # slurp + reduce
+  tq -f filter.jq data.json                        # filter from file
+  tq --stream --json -c '.' large.toon             # stream large files
 
 Output flags:
       --json                   output JSON instead of TOON

--- a/cmd/tq/flags.go
+++ b/cmd/tq/flags.go
@@ -91,12 +91,12 @@ func parseFlags() (*config, []string) {
 	cfg.argPairs = argPairs
 	cfg.argjsonPairs = argjsonPairs
 
-	flag.CommandLine.Parse(remaining)
+	_ = flag.CommandLine.Parse(remaining)
 	return cfg, flag.Args()
 }
 
 func printUsage() {
-	fmt.Fprint(os.Stdout, `Usage: tq [flags] <filter> [file...]
+	_, _ = fmt.Fprint(os.Stdout, `Usage: tq [flags] <filter> [file...]
 
 tq is a command-line TOON/JSON processor. Like jq, but for TOON.
 

--- a/cmd/tq/main.go
+++ b/cmd/tq/main.go
@@ -11,7 +11,11 @@ const (
 	exitRuntime  = 5 // jq filter runtime error
 )
 
-var version = "dev"
+var (
+	version = "dev"
+	commit  = "unknown"
+	date    = "unknown"
+)
 
 func main() {
 	os.Exit(run())

--- a/cmd/tq/main_test.go
+++ b/cmd/tq/main_test.go
@@ -106,9 +106,9 @@ func TestCLI(t *testing.T) {
 		{"delimiter tab", `[1,2,3]`, []string{"--delimiter", "tab", "."}, 0, "\t", ""},
 		{"delimiter pipe", `[1,2,3]`, []string{"--delimiter", "pipe", "."}, 0, "|", ""},
 
-		// Variables
-		{"arg variable", "null", []string{"-n", "--arg", "name", "--arg", "Alice", "$name"}, 0, "Alice", ""},
-		{"argjson variable", "null", []string{"-n", "--json", "-c", "--argjson", "data", "--argjson", `{"k":"v"}`, "$data"}, 0, `{"k":"v"}`, ""},
+		// Variables (jq-style: --arg NAME VALUE)
+		{"arg variable", "null", []string{"-n", "--arg", "name", "Alice", "$name"}, 0, "Alice", ""},
+		{"argjson variable", "null", []string{"-n", "--json", "-c", "--argjson", "data", `{"k":"v"}`, "$data"}, 0, `{"k":"v"}`, ""},
 
 		// Exit status
 		{"exit status with output", `{"a":1}`, []string{"-e", "."}, 0, "a", ""},
@@ -153,10 +153,20 @@ func TestCLI(t *testing.T) {
 		// Quiet mode
 		{"quiet suppresses warning", `{}`, []string{"--stream", "--quiet", "--json", "-c", "select(false) | sort"}, 0, "", ""},
 
-		// Help output
-		{"help shows groups", "", []string{"--help"}, 0, "", "Output flags:"},
-		{"help shows env", "", []string{"--help"}, 0, "", "TQ_STREAM_THRESHOLD"},
-		{"help shows docs link", "", []string{"--help"}, 0, "", "github.com/tq-lang/tq"},
+		// Help output (stdout)
+		{"help shows groups", "", []string{"--help"}, 0, "Output flags:", ""},
+		{"help shows env", "", []string{"--help"}, 0, "TQ_STREAM_THRESHOLD", ""},
+		{"help shows docs link", "", []string{"--help"}, 0, "github.com/tq-lang/tq", ""},
+		{"help examples use toon", "", []string{"--help"}, 0, "echo 'name Alice'", ""},
+		{"help to stdout", "", []string{"--help"}, 0, "Usage: tq", ""},
+
+		// --arg edge cases
+		{"arg jq style", "null", []string{"-n", "--arg", "x", "hello", "$x"}, 0, "hello", ""},
+		{"argjson jq style", "null", []string{"-n", "--json", "-c", "--argjson", "d", `[1,2]`, "$d"}, 0, "[1,2]", ""},
+		{"arg missing value", "null", []string{"-n", "--arg", "name"}, 2, "", ""},
+
+		// Version format
+		{"version format", "", []string{"--version"}, 0, "tq dev", ""},
 
 		// Errors
 		{"invalid filter", `{}`, []string{".[invalid|||"}, 3, "", "parse error"},

--- a/cmd/tq/run.go
+++ b/cmd/tq/run.go
@@ -11,7 +11,11 @@ func run() int {
 	cfg, args := parseFlags()
 
 	if cfg.version {
-		fmt.Println("tq " + version)
+		if commit != "unknown" || date != "unknown" {
+			fmt.Printf("tq %s (%s, %s)\n", version, commit, date)
+		} else {
+			fmt.Println("tq " + version)
+		}
 		return exitOK
 	}
 

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -559,7 +559,7 @@ printf 'users[2]{name,age}:\n  Alice,30\n  Bob,25' | tq --delimiter tab '.users'
 Pass a string variable with `--arg`:
 
 ```tq
-echo 'null' | tq --arg name --arg Alice '$name'
+echo 'null' | tq --arg name Alice '$name'
 # output
 Alice
 ```
@@ -567,7 +567,7 @@ Alice
 Use a variable in a filter:
 
 ```tq
-printf 'users[2]{name,role}:\n  Alice,admin\n  Bob,user' | tq --arg role --arg admin '.users[] | select(.role == $role) | .name'
+printf 'users[2]{name,role}:\n  Alice,admin\n  Bob,user' | tq --arg role admin '.users[] | select(.role == $role) | .name'
 # output
 Alice
 ```
@@ -575,7 +575,7 @@ Alice
 Pass a structured JSON variable with `--argjson`:
 
 ```tq
-echo 'null' | tq --argjson threshold --argjson 80 'if $threshold > 50 then "above" else "below" end'
+echo 'null' | tq --argjson threshold 80 'if $threshold > 50 then "above" else "below" end'
 # output
 above
 ```

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -322,18 +322,18 @@ tq: --json and --toon are mutually exclusive
 
 ### Missing flag value (`--arg`)
 
-`--arg` requires a name and a value as two separate flag invocations.
+`--arg` requires a name and a value as two positional arguments.
 
 ```tq
-echo '{}' | tq --arg name '$name'
+echo '{}' | tq --arg name
 # output error (exit: 2)
-tq: --arg requires pairs of name and value
+tq: --arg requires NAME and VALUE arguments
 ```
 
-**Fix:** provide both name and value: `--arg name --arg Alice`.
+**Fix:** provide both name and value: `--arg name Alice`.
 
 ```tq
-echo '{}' | tq --arg name --arg Alice '"Hello, " + $name'
+echo '{}' | tq --arg name Alice '"Hello, " + $name'
 # output
 "Hello, Alice"
 ```
@@ -341,15 +341,15 @@ echo '{}' | tq --arg name --arg Alice '"Hello, " + $name'
 ### Invalid JSON value for `--argjson`
 
 ```tq
-echo '{}' | tq --argjson val --argjson 'notjson' '$val'
+echo '{}' | tq --argjson val 'notjson' '$val'
 # output error (exit: 2)
 tq: --argjson value for "val" is not valid JSON: invalid character 'o' in literal null (expecting 'u')
 ```
 
-**Fix:** supply valid JSON: `--argjson val --argjson '42'` or `--argjson val --argjson '{"x":1}'`.
+**Fix:** supply valid JSON: `--argjson val '42'` or `--argjson val '{"x":1}'`.
 
 ```tq
-echo '{}' | tq --argjson val --argjson '42' '$val + 1'
+echo '{}' | tq --argjson val '42' '$val + 1'
 # output
 43
 ```
@@ -511,7 +511,7 @@ This is useful for defensive pipelines, but be careful — the output is now a s
 | `tq: parse error: unterminated string literal` | Missing closing `"` in filter | Add the closing `"` |
 | `tq: parse error: unexpected token ";"` | Semicolon used as separator | Use `,` (multi-output) or `\|` (pipe) |
 | `tq: compile error: function not defined: foo/1` | Calling a nonexistent built-in | Check spelling or define the function with `def` |
-| `tq: compile error: variable not defined: $x` | Using `$x` without binding it | Add `--arg x --arg value` or bind with `as` |
+| `tq: compile error: variable not defined: $x` | Using `$x` without binding it | Add `--arg x value` or bind with `as` |
 | `tq: cannot iterate over: null` | `.field[]` where `.field` is null | Use `[]?` or `(.field // []) \| .[]` |
 | `tq: cannot iterate over: boolean (true)` | `.[]` on a boolean | Check type first; iterate the correct field |
 | `tq: expected an object but got: number (42)` | `.field` access on non-object | Check input type; use correct path |
@@ -523,7 +523,7 @@ This is useful for defensive pipelines, but be careful — the output is now a s
 | `tq: open file.json: no such file or directory` | Input file missing | Check path; use `-` for stdin |
 | `tq: open filter.jq: no such file or directory` | `-f` filter file missing | Fix path or pass filter inline |
 | `tq: unknown delimiter "x" (use comma, tab, or pipe)` | Invalid `--delimiter` value | Use `comma`, `tab`, or `pipe` |
-| `tq: --arg requires pairs of name and value` | Odd number of `--arg` tokens | Each variable needs a name and a value |
-| `tq: --argjson value for "x" is not valid JSON: …` | Value is not valid JSON | Pass valid JSON: `--argjson x --argjson '42'` |
+| `tq: --arg requires NAME and VALUE arguments` | Missing name or value after `--arg` | Each variable needs a name and a value |
+| `tq: --argjson value for "x" is not valid JSON: …` | Value is not valid JSON | Pass valid JSON: `--argjson x '42'` |
 | `tq: --json and --toon are mutually exclusive` | Both output flags set | Use one or neither |
 | *(exit 4, no output)* | `--exit-status` with no filter output | Fix the filter, or drop `-e` if empty output is fine |

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -510,14 +510,13 @@ echo '{"price":"42.50"}' | tq '.price | tonumber'
 
 ## 8. Variables and Shell Integration
 
-`--arg` injects a shell string as a jq variable. tq uses the flag twice — once
-for the name and once for the value: `--arg name --arg value`. This differs from
-jq's single-flag form `--arg name value`.
+`--arg` injects a shell string as a jq variable using `--arg name value`
+(two positional arguments after the flag), matching jq's syntax exactly.
 
 Pass a string variable and use it in a filter:
 
 ```tq
-tq -n --arg greeting --arg Hello '$greeting'
+tq -n --arg greeting Hello '$greeting'
 # output
 Hello
 ```
@@ -525,23 +524,22 @@ Hello
 Use a variable to parameterise a filter at runtime:
 
 ```tq
-echo '{"users":[{"name":"Alice","dept":"eng"},{"name":"Bob","dept":"sales"},{"name":"Carol","dept":"eng"}]}' | tq --arg dept --arg eng '[.users[] | select(.dept == $dept) | .name]'
+echo '{"users":[{"name":"Alice","dept":"eng"},{"name":"Bob","dept":"sales"},{"name":"Carol","dept":"eng"}]}' | tq --arg dept eng '[.users[] | select(.dept == $dept) | .name]'
 # output
 [2]: Alice,Carol
 ```
 
-`--argjson` also uses repeated flags (`--argjson name --argjson value`) and
-parses the value as JSON, so numbers, booleans, and objects remain their
-correct types:
+`--argjson` works the same way (`--argjson name value`) and parses the value
+as JSON, so numbers, booleans, and objects remain their correct types:
 
 ```tq
-tq -n --argjson limit --argjson 5 '[range($limit)]'
+tq -n --argjson limit 5 '[range($limit)]'
 # output
 [5]: 0,1,2,3,4
 ```
 
 ```tq
-tq -n --argjson config --argjson '{"limit":10,"debug":false}' '$config.limit'
+tq -n --argjson config '{"limit":10,"debug":false}' '$config.limit'
 # output
 10
 ```

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -490,10 +490,8 @@ tq -s 'map({name, replicas}) | sort_by(.replicas) | reverse' svc-web.toon svc-ap
 
 Construct an object from command-line variables using `-n` and `--arg`:
 
-> **Note:** tq uses `--arg name --arg value` (two flags per variable), unlike jq which uses `--arg name value` (one flag with two arguments).
-
 ```tq
-tq -n --arg env --arg production --arg version --arg "2.1.3" '{env: $env, version: $version, deployedAt: "2024-03-01"}'
+tq -n --arg env production --arg version "2.1.3" '{env: $env, version: $version, deployedAt: "2024-03-01"}'
 # output
 deployedAt: 2024-03-01
 env: production
@@ -514,7 +512,7 @@ tq -n '[range(1;4) | {id: ., name: ("user-" + (. | tostring)), active: true}]'
 Attach a structured JSON object to existing data with `--argjson`:
 
 ```tq
-echo '{"name":"web","replicas":3}' | tq --argjson limits --argjson '{"cpu":"500m","memory":"256Mi"}' '. + {limits: $limits}'
+echo '{"name":"web","replicas":3}' | tq --argjson limits '{"cpu":"500m","memory":"256Mi"}' '. + {limits: $limits}'
 # output
 limits:
   cpu: 500m
@@ -526,7 +524,7 @@ replicas: 3
 Enrich a TOON document with a runtime variable:
 
 ```tq
-printf 'name: web\nreplicas: 3\nstatus: healthy' | tq --arg region --arg "us-east-1" '. + {region: $region}'
+printf 'name: web\nreplicas: 3\nstatus: healthy' | tq --arg region "us-east-1" '. + {region: $region}'
 # output
 name: web
 region: us-east-1

--- a/docs/vs-jq.md
+++ b/docs/vs-jq.md
@@ -184,8 +184,8 @@ Use `--stream` when processing large JSON or TOON files with O(depth) memory.
 | `-e` | Exit 4 when filter produces no output |
 | `-j` | Join output: no newline between values |
 | `-f file` | Read filter from file |
-| `--arg name --arg value` | Bind a string variable (see note below) |
-| `--argjson name --argjson value` | Bind a JSON variable |
+| `--arg name value` | Bind a string variable |
+| `--argjson name value` | Bind a JSON variable |
 | `--stream` | Output path-value pairs for streaming |
 
 **tq-specific flags:**
@@ -223,10 +223,10 @@ tq -n '1 + 1'
 2
 ```
 
-String variable — note the syntax difference from jq: tq uses a repeated flag (`--arg name --arg value`) because flags accept one argument each, whereas jq uses `--arg name value`:
+String variable — tq uses the same syntax as jq (`--arg name value`):
 
 ```tq
-tq -n --arg name --arg Alice '$name'
+tq -n --arg name Alice '$name'
 # output
 Alice
 ```


### PR DESCRIPTION
## Summary
- **TOON help examples**: replaced JSON examples in `--help` with TOON input (e.g. `echo 'name Alice'`), keeping one `--json` conversion example
- **Help to stdout**: `printUsage()` writes to stdout so `tq --help | grep` works
- **`--arg`/`--argjson` jq syntax**: manual pre-parsing of `--arg NAME VALUE` (two positional args) before pflag, matching jq exactly
- **Version build info**: added `commit` and `date` ldflags to goreleaser and Makefile; version output shows `tq 0.1.0 (abc1234, 2026-03-18)` in release builds

## Test plan
- [x] All existing tests updated and passing
- [x] New tests: `help_to_stdout`, `help_examples_use_toon`, `arg_jq_style`, `argjson_jq_style`, `arg_missing_value`, `version_format`
- [x] Doc tests (`TestDocs`) updated for new `--arg` syntax and error messages
- [ ] `tq --help | head` — verify stdout
- [ ] `tq -n --arg name Alice '$name'` — prints `Alice`
- [ ] `make build && ./tq --version` — shows commit and date

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)