### PR TITLE
chore: add project CLAUDE.md and Claude Code skills

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,35 @@
+# tq
+
+Command-line TOON/JSON processor. Like jq, but for TOON.
+
+## Quality gate (must pass before committing)
+
+Run `/tq-check` which runs, in order:
+
+1. `golangci-lint run` — required, includes errcheck, gocritic, errorlint, staticcheck
+2. `go vet ./...`
+3. `go build ./cmd/tq`
+4. `go test -race -short -count=1 ./...` — includes TestDocs (doc example tests)
+
+This mirrors `.github/workflows/ci.yml` exactly.
+
+## Boy Scout Rule
+
+We take full ownership of the codebase. There is no "pre-existing" code — if you touch a file and see issues, fix them. Specifically:
+
+- **Never exclude lint findings.** If a linter flags something, fix it. Do not add exclusions, `//nolint` comments, or raise thresholds to avoid fixing code.
+- **Refactor complex functions.** gocyclo is set to 10. If a function exceeds it, break it into smaller functions with clear responsibilities.
+- **Use `errors.Is`/`errors.As`** instead of `==` for error comparisons (errorlint).
+- **Don't shadow imports.** If a parameter name conflicts with an import (e.g. `bytes`), rename the parameter.
+- If a fix is too large for the current PR, open a GitHub issue with `gh issue create` — but never silently skip it.
+
+## Conventions
+
+- Conventional Commits: `feat`, `fix`, `refactor`, `build`, `ci`, `chore`, `docs`, `test`
+- Discard return values explicitly with `_ =` or `_, _ =` (errcheck linter)
+- Doc examples in `docs/*.md` are tested by `TestDocs` — keep code blocks in sync
+- `--arg`/`--argjson` use jq-style syntax: `--arg NAME VALUE` (two positional args)
+
+## Linters (`.golangci.yml`)
+
+Enabled beyond defaults: gocritic (diagnostic + style + performance), errorlint, nilerr, reassign, wastedassign, forcetypeassert, exhaustive, errchkjson, perfsprint, forbidigo, nolintlint, bodyclose, asciicheck, bidichk, copyloopvar, durationcheck, errname, goconst, nakedret, usestdlibvars, whitespace, makezero, intrange, mirror, tparallel, dupl (75 tokens), maintidx (under 20), funlen (60 lines / 40 statements). `errcheck.check-type-assertions: true`. gocyclo max complexity: 10 (Go best practice — refactor if exceeded, never raise). Source files max 500 LOC, test files max 1000 LOC.

--- a/.claude/skills/tq-check.md
+++ b/.claude/skills/tq-check.md
@@ -1,0 +1,46 @@
+---
+name: tq-check
+description: "Run the tq quality gate (lint, vet, test, build). Mirrors CI exactly. Use when the user says /tq-check, 'run checks', or before committing."
+---
+
+# tq Quality Gate
+
+Run the same checks as CI (`.github/workflows/ci.yml`). Stop on first failure — never fix anything.
+
+## Steps (run in order, stop on first failure)
+
+### 1. Lint
+
+```bash
+golangci-lint run
+```
+
+This is the single biggest source of CI failures. It runs errcheck, govet, and many other linters configured in the repo.
+
+### 2. Vet
+
+```bash
+go vet ./...
+```
+
+### 3. Build
+
+```bash
+go build ./cmd/tq
+```
+
+### 4. Test (race + short)
+
+```bash
+go test -race -short -count=1 ./...
+```
+
+This runs all tests including `TestDocs` (doc example tests) but skips the slow memory tests. The `-race` flag matches CI.
+
+## Rules
+
+- NEVER fix, edit, or modify any file — you are a read-only reporter
+- NEVER re-run a failing step — stop on first failure
+- Show the full error output for any failing step
+- End with: `RESULT: ALL PASSED` or `RESULT: FAILURES DETECTED`
+- If golangci-lint is not installed, report it and fail — it's required for this repo

--- a/.claude/skills/tq-review.md
+++ b/.claude/skills/tq-review.md
@@ -1,0 +1,251 @@
+---
+name: tq-review
+description: "Review Go code for correctness, edge cases, and idiomatic Go. Use when the user says /tq-review, 'review this', 'review the diff', or before shipping a PR."
+argument-hint: "[file, directory, or 'diff' to review staged/unstaged changes]"
+disable-model-invocation: true
+---
+
+# Go Code Review
+
+You are now in code review mode. Review Go source files for correctness, edge
+cases, defensive coding, and idiomatic Go. Focus on bugs that pass tests but
+break in production or under unexpected input.
+
+## Scope
+
+$ARGUMENTS
+
+- If the user names specific files or directories, scope your review to those.
+- If the user says "diff", review only the files changed in `git diff` and
+  `git diff --cached` (staged + unstaged). This is the most common use case.
+- If no argument is given, review files changed on the current branch vs main:
+  `git diff main...HEAD --name-only -- '*.go'`
+- For large scopes, use `AskUserQuestion` to narrow down.
+
+## Workflow
+
+1. **Read** — Read every file in scope thoroughly. For diffs, also read the
+   surrounding context (the full function, callers, tests). Don't review code
+   you haven't read.
+
+2. **Analyse** — Apply the checklist below. For each finding, verify it's real
+   by tracing data flow and checking whether tests cover the case.
+
+3. **Report** — Present findings grouped by severity. For each finding, show:
+   - The file and line(s)
+   - What the issue is (be specific — show the problematic code)
+   - Why it matters (what input or scenario triggers the bug)
+   - A concrete fix (code snippet)
+
+4. **Classify** — Mark each finding as:
+   - **Blocking** — must fix before merging (bugs, data corruption, security)
+   - **Should fix** — fix in this PR if easy, otherwise file an issue
+   - **Nit** — style or minor improvement, author's discretion
+
+## Checklist — What to Look For
+
+Work through these categories for each file/diff.
+
+### 1. Input validation at boundaries
+
+Functions that accept external input (CLI args, file contents, env vars,
+network data) must validate before processing.
+
+**Common misses in this codebase:**
+- `--arg`/`--argjson` values that look like flags (`--json`, `-n`) being
+  silently consumed as variable names
+- Flag values that are empty strings when they shouldn't be
+- File paths that are `-` (stdin convention) but handled as regular files
+
+```go
+// Bad: silently treats --json as a variable name
+name := args[i+1]  // could be "--json"
+
+// Good: reject flag-like names
+if strings.HasPrefix(name, "-") {
+    return fmt.Errorf("variable name %q must not start with a dash", name)
+}
+```
+
+### 2. Boolean and condition logic
+
+Subtle bugs in `||` vs `&&`, negation, short-circuit evaluation, and
+conditions that are coincidentally correct.
+
+**Patterns to check:**
+- `||` where `&&` was intended (or vice versa) — read the condition in plain
+  English and verify the logic table
+- Conditions that work today because two variables happen to have correlated
+  values, but the correlation isn't guaranteed
+- `!a || !b` vs `!(a && b)` — De Morgan's law errors
+- Early returns that skip cleanup or state updates
+
+```go
+// Suspicious: shows extended version if EITHER is set
+// But if only one is set, output looks odd: "tq 0.1.0 (abc1234, unknown)"
+if commit != "unknown" || date != "unknown" {
+
+// Defensive: require BOTH to be set
+if commit != "unknown" && date != "unknown" {
+```
+
+### 3. Error handling
+
+Go's explicit error handling is a strength, but only if errors are actually
+checked and propagated correctly.
+
+**Patterns to check:**
+- Unchecked error returns (the errcheck linter catches most, but not all)
+- Errors logged but not returned (swallowed)
+- `err` variable shadowed by `:=` in an inner scope
+- Error messages that don't include enough context to debug
+- `defer` with error returns — the deferred error is silently dropped
+- `fmt.Errorf` wrapping without `%w` (loses error chain)
+
+```go
+// Bad: shadows outer err, deferred close error lost
+func process(path string) error {
+    f, err := os.Open(path)
+    if err != nil { return err }
+    defer f.Close()  // error from Close() is dropped
+
+    if data, err := io.ReadAll(f); err != nil {  // shadows outer err
+        return err
+    }
+}
+```
+
+### 4. Slice and map edge cases
+
+**Patterns to check:**
+- Nil slice vs empty slice — `len(s) == 0` is true for both, but
+  `json.Marshal(nil)` → `null` vs `json.Marshal([]int{})` → `[]`
+- Appending to a sub-slice can mutate the original (shared backing array)
+- Iterating and modifying the same slice/map
+- Map access without comma-ok when zero value is meaningful
+- `range` over nil slice/map is safe (no-op), but code after the loop may
+  assume the loop body ran at least once
+
+### 5. Concurrency and race conditions
+
+**Patterns to check:**
+- Shared state accessed without synchronization
+- Goroutine leaks (launched but never joined or cancelled)
+- Channel operations that can deadlock
+- `sync.WaitGroup` Add/Done mismatch
+- Reading from a closed channel (returns zero value — silent bug)
+
+### 6. Resource lifecycle
+
+**Patterns to check:**
+- `os.Open` / `os.Create` without `defer f.Close()`
+- `http.Response.Body` not closed
+- `context.WithCancel` / `WithTimeout` without calling cancel
+- Temp files created but not cleaned up on error paths
+- `defer` in a loop (defers pile up, only run when function returns)
+
+### 7. String and encoding
+
+**Patterns to check:**
+- `len(s)` gives bytes, not runes — use `utf8.RuneCountInString` for character
+  count
+- `s[i]` gives a byte, not a rune — use `range s` for rune iteration
+- String concatenation in a loop — use `strings.Builder`
+- `fmt.Sprintf` when `strconv` would be clearer and faster
+- Raw string literals with backticks that contain backticks (can't be escaped)
+
+### 8. API contract mismatches
+
+**Patterns to check:**
+- pflag/cobra quirks: `StringArray` vs `StringSlice` (comma splitting),
+  `Changed()` for detecting explicit flag use
+- `io.Reader` / `io.Writer` contracts: partial reads are valid, `Write` must
+  return `len(p)` or an error
+- `json.Decoder` vs `json.Unmarshal` — decoder handles streams, unmarshal
+  expects complete input
+- `os.Exit` bypasses deferred functions — use a `run() int` pattern instead
+
+### 9. Test quality
+
+**Patterns to check:**
+- Tests that verify behavior coincidentally (test passes but for the wrong
+  reason)
+- Substring assertions that are too loose (`Contains("a")` matches anything)
+- Missing error case tests — happy path is tested but error paths aren't
+- Table-driven tests where a new case should be added for the code being changed
+- Test helpers that call `t.Fatal` from a goroutine (must use `t.Error` +
+  return instead)
+
+### 10. Go-specific idioms
+
+**Patterns to check:**
+- Exported functions/types without doc comments (golint)
+- Stuttering names: `package user` with `type UserService` → `type Service`
+- `interface{}` instead of `any` (Go 1.18+)
+- Unnecessary pointer receivers on small structs
+- `init()` functions with side effects (makes testing hard)
+- Constants that should be iota enums
+
+## Output Format
+
+Present your review as:
+
+```markdown
+## Review: <scope description>
+
+### Blocking
+
+#### 1. <title> — `file.go:NN`
+
+<description of the issue>
+
+```go
+// Current
+<problematic code>
+
+// Suggested
+<fixed code>
+```
+
+**Why:** <what breaks and when>
+
+---
+
+### Should Fix
+
+#### 1. <title> — `file.go:NN`
+...
+
+### Nits
+
+- `file.go:NN` — <one-liner description and fix>
+```
+
+## Calibration
+
+- **Be precise.** Every finding must reference specific code with line numbers.
+  Don't say "consider adding validation" — say where, what input, what check.
+- **Prove it.** For each finding, explain the concrete scenario that triggers
+  the bug. "If someone passes `--arg --json value`" is good. "This could
+  theoretically cause issues" is not.
+- **Don't pad.** If the code is solid, say so. A review with zero findings is
+  a valid outcome. Don't manufacture nits to seem thorough.
+- **Respect the author's style.** Don't flag things that are a matter of
+  preference unless they cause real confusion. `if err != nil { return err }` on
+  one line vs three is not worth mentioning.
+- **Check tests before flagging.** If you think an edge case is unhandled, check
+  whether a test already covers it. If so, mention the test exists and move on.
+- **Separate suggestions from issues.** "This works but could be cleaner" is a
+  nit. "This breaks when input contains dashes" is blocking. Don't mix them.
+
+## Critical Rules
+
+- **Read before reviewing.** Never comment on code you haven't read. Read the
+  full function, its callers, and its tests.
+- **Don't fix code.** Your job is to identify issues and suggest fixes. Don't
+  edit files unless the user asks you to apply your suggestions.
+- **Ask when uncertain.** If you're unsure whether something is a real issue or
+  intentional, use `AskUserQuestion` rather than guessing.
+- **No false positives.** A false positive wastes more of the author's time than
+  a missed issue. If you're less than 80% confident, skip it or downgrade to a
+  nit with a question mark.

--- a/.claude/skills/tq-ship.md
+++ b/.claude/skills/tq-ship.md
@@ -1,0 +1,127 @@
+---
+name: tq-ship
+description: "Full ship workflow: check → commit → push → open PR. Use when the user says /tq-ship, 'ship it', 'commit and open PR', or wants to land changes."
+---
+
+# tq: Check → Commit → Push → Open PR
+
+Two-phase approach: haiku subagents handle mechanical tasks, the parent agent (you) owns code fixes.
+
+`$ARGUMENTS` may contain: commit message hint, issue number(s), or PR title.
+
+## Step 1: Run tq Quality Gate (subagent)
+
+Launch a subagent using the Agent tool with `model: "haiku"` and `subagent_type: "general-purpose"`.
+
+Prompt:
+
+~~~
+Run the tq quality gate. Do NOT fix anything — just report results.
+
+## Checks (in order, stop on first failure)
+
+1. `golangci-lint run` — REQUIRED, do not skip. This is the #1 CI failure source (errcheck, govet, etc.)
+2. `go vet ./...`
+3. `go build ./cmd/tq`
+4. `go test -race -short -count=1 ./...` — includes TestDocs (doc example tests that verify code blocks in docs/*.md)
+
+## Rules
+
+- NEVER fix, edit, or modify any file
+- NEVER re-run a failing step — stop on first failure
+- Show full error output for failures
+- End with: `RESULT: ALL PASSED` or `RESULT: FAILURES DETECTED`
+~~~
+
+## Step 2: Fix failures (parent agent — you)
+
+If `RESULT: ALL PASSED`, skip to Step 3.
+
+If `RESULT: FAILURES DETECTED`:
+
+1. Read the error output from the subagent
+2. **You fix the code** — common fixes for this repo:
+   - **errcheck**: add `_ =` or `_, _ =` for intentionally discarded return values
+   - **TestDocs failures**: doc examples in `docs/*.md` are tested — update the code block or expected output
+   - **Test failures**: read output carefully, fix with Edit tool
+3. After fixing, re-run Step 1
+4. Max 3 rounds — if still failing, ask the user
+
+## Step 3: Commit → Push → Open PR (subagent)
+
+Launch a subagent using the Agent tool with `model: "haiku"` and `subagent_type: "general-purpose"`.
+
+Include `$ARGUMENTS` in the prompt if provided.
+
+Prompt:
+
+~~~
+Create a git commit, push, and open a pull request for the tq project.
+
+## Phase 1: Commit
+
+1. Run `git status` to see all changes (never use -uall flag)
+2. Run `git diff` to review staged and unstaged changes
+3. Run `git log --oneline -5` to match commit style
+4. Stage ONLY modified files by name — `git add path/to/file` for each
+5. NEVER use `git add -A` or `git add .`
+6. Draft commit message in Conventional Commits format:
+   ```
+   <type>(<scope>): <subject>
+
+   [optional body]
+
+   [footer: Closes #<issue> | Part of #<issue>]
+   ```
+   Types: feat, fix, refactor, build, ci, chore, docs, style, perf, test
+7. Create commit using a HEREDOC:
+   ```
+   git commit -m "$(cat <<'EOF'
+   <message>
+
+   Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+   EOF
+   )"
+   ```
+8. Run `git status` to verify clean working tree
+
+## Phase 2: Push
+
+1. Check upstream: `git rev-parse --abbrev-ref @{upstream} 2>/dev/null`
+2. If no upstream: `git push -u origin HEAD`
+3. If upstream exists: `git push`
+
+## Phase 3: Open Pull Request
+
+1. Check if PR already exists: `gh pr view --json url 2>/dev/null`
+   - If exists: report its URL and skip to summary
+2. Gather context:
+   - `git log main..HEAD --oneline` — all commits on branch
+   - Extract issue number from branch name (patterns: `fix/cli-audit-35` → `#35`, `feat/issue-21-desc` → `#21`)
+3. Create PR:
+   ```
+   gh pr create --title "<type>(<scope>): <short description>" --body "$(cat <<'EOF'
+   ## Summary
+   <1-3 bullet points>
+
+   ## Test plan
+   - [ ] CI passes (lint, vet, test, build)
+   - [ ] <specific verification steps>
+
+   Closes #<issue>
+
+   🤖 Generated with [Claude Code](https://claude.com/claude-code)
+   EOF
+   )"
+   ```
+4. Report the PR URL
+
+## Rules
+
+- Check `git status` before staging
+- Do not amend unless explicitly asked
+- After hook failure: create NEW commit, never amend
+- Keep PR title under 70 chars
+- Always link to GitHub issue with `Closes #N` if issue number is detectable
+- Report final summary: commit hash, push status, PR URL
+~~~


### PR DESCRIPTION
## Summary
- Add `.claude/CLAUDE.md` with quality gate instructions, Boy Scout Rule, and project conventions
- Add `/tq-check` skill — runs lint → vet → build → test, mirrors CI exactly
- Add `/tq-ship` skill — full check → fix → commit → push → PR workflow
- Add `/tq-review` skill — Go code review checklist with 10 categories tailored to this repo

## Test plan
- [x] `/tq-check` runs successfully
- [x] Skills are discoverable via `/` autocomplete
- [x] CI passes (skills are markdown-only, no code changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)