### PR TITLE
fix: correct help examples and README --arg docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ Use `-` as a file argument to read from stdin explicitly (e.g. `tq '.key' -`).
 | `--indent N` | Set indentation width |
 | `--delimiter` | TOON output delimiter: `comma`, `tab`, `pipe` |
 | `--stream` | Output path-value pairs for streaming |
-| `--arg NAME --arg VALUE` | Pass a string variable to the filter |
-| `--argjson NAME --argjson VALUE` | Pass a JSON variable to the filter |
+| `--arg NAME VALUE` | Pass a string variable to the filter |
+| `--argjson NAME VALUE` | Pass a JSON variable to the filter |
 | `-f`, `--from-file` | Read filter from file |
 | `--version` | Print version |
 | `-h`, `--help` | Show help with examples |

--- a/cmd/tq/flags.go
+++ b/cmd/tq/flags.go
@@ -101,8 +101,8 @@ func printUsage() {
 tq is a command-line TOON/JSON processor. Like jq, but for TOON.
 
 Examples:
-  echo 'name Alice' | tq '.name'                  # field access
-  echo 'a 1' | tq --json '.'                      # convert to JSON
+  echo 'name: Alice' | tq '.name'                 # field access
+  echo 'a: 1' | tq --json '.'                     # convert to JSON
   cat data.toon | tq '.users[] | .name'            # iterate array
   tq -n '1 + 1'                                    # null input
   tq '.key' file1.json file2.toon                  # multiple files

--- a/cmd/tq/main_test.go
+++ b/cmd/tq/main_test.go
@@ -157,7 +157,7 @@ func TestCLI(t *testing.T) {
 		{"help shows groups", "", []string{"--help"}, 0, "Output flags:", ""},
 		{"help shows env", "", []string{"--help"}, 0, "TQ_STREAM_THRESHOLD", ""},
 		{"help shows docs link", "", []string{"--help"}, 0, "github.com/tq-lang/tq", ""},
-		{"help examples use toon", "", []string{"--help"}, 0, "echo 'name Alice'", ""},
+		{"help examples use toon", "", []string{"--help"}, 0, "echo 'name: Alice'", ""},
 		{"help to stdout", "", []string{"--help"}, 0, "Usage: tq", ""},
 
 		// --arg edge cases


### PR DESCRIPTION
## Summary
- Fix TOON syntax in `tq --help` examples: `echo 'name Alice'` → `echo 'name: Alice'` (was invalid TOON, missing colons)
- Fix README `--arg`/`--argjson` flag table: `--arg NAME --arg VALUE` → `--arg NAME VALUE`
- Update repo description to "Command-line TOON/JSON processor — like jq, but for TOON"
- Add topics: tq, toon, cli, jq, json, bash, zsh, command-line, data-processing, golang

## Test plan
- [x] `golangci-lint run` — 0 issues
- [x] `go vet ./...` — clean
- [x] `go build ./cmd/tq` — clean
- [x] `go test -race -short -count=1 ./...` — all pass (including updated help text assertion)

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)