### PR TITLE
fix: extract --arg/--argjson literals into constants (goconst)

### DIFF
--- a/cmd/tq/flags.go
+++ b/cmd/tq/flags.go
@@ -76,8 +76,14 @@ func (e *varArgExtractor) processArg(args []string, i int) (int, error) {
 	return e.consumeVarPair(args, i, a)
 }
 
+// jq-style variable flags.
+const (
+	argFlag     = "--arg"
+	argJSONFlag = "--argjson"
+)
+
 func isVarFlag(a string) bool {
-	return a == "--arg" || a == "--argjson"
+	return a == argFlag || a == argJSONFlag
 }
 
 func (e *varArgExtractor) consumeVarPair(args []string, i int, a string) (int, error) {
@@ -96,7 +102,7 @@ func checkVarPairArgs(args []string, i int, a string) error {
 }
 
 func (e *varArgExtractor) appendVarPair(flagName, name, value string) {
-	if flagName == "--arg" {
+	if flagName == argFlag {
 		e.argPairs = append(e.argPairs, name, value)
 	} else {
 		e.argjsonPairs = append(e.argjsonPairs, name, value)


### PR DESCRIPTION
## Problem

`main` currently fails its own `lint` job:

```
cmd/tq/flags.go:80:14: string `--arg` has 5 occurrences, make it a constant (goconst)
```

CI uses golangci-lint `latest` (now **v2.12.2**), whose `goconst` counts the three `_test.go` occurrences of `"--arg"` toward the threshold (2 source + 3 test = 5). Findings *in* test files stay suppressed by `.golangci.yml`, but the count still trips the finding reported on `flags.go`.

Because branch protection requires the `lint` check to pass and branches to be up-to-date with main (`strict`), **every open Dependabot PR inherits this red check and cannot merge.**

## Fix

Extract `argFlag` / `argJSONFlag` constants in `flags.go` and use them — the minimal, Boy-Scout-correct fix (no `//nolint`, no threshold change, no exclusion).

## Verification

Full local quality gate (mirrors CI):

- `golangci-lint run ./...` — No issues found
- `go vet ./...` — clean
- `go build ./cmd/tq` — ok
- `go test -race -short -count=1 ./...` — 498 passed

Unblocks #73, #74, #77, #80, #81.

🤖 Generated with [Claude Code](https://claude.com/claude-code)