### PR TITLE
chore(claude): add enforcement hooks + commit agent/command/skill setup

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -45,6 +45,14 @@ Three-layer system for structured development:
 
 Agent personas live in `.claude/agents/` (dev.md, reviewer.md, test-doc.md). Commands in `.claude/commands/`. Skills in `.claude/skills/` with multi-phase orchestration (e.g. `/tq-e2e` runs `triage.md` then `fix.md`).
 
+## Hooks (`.claude/settings.json`)
+
+Enforced policy that doesn't rely on the agent remembering it. Scripts in `.claude/hooks/` (POSIX sh, `jq`-parsed, fail open). Restart the session after editing them to reload.
+
+- **`block-no-verify.sh`** — PreToolUse(Bash): blocks `git commit/push --no-verify`, keeping the quality gate non-optional. Quote-aware, so `--no-verify` inside a commit message is allowed.
+- **`gofmt.sh`** — PostToolUse(Edit|Write): runs `gofmt -w` on edited `.go` files to cut lint churn before `/tq-check`.
+- **`guard-secrets.sh`** — PreToolUse(Read): blocks reads of secret files (`.env`, `*.pem`, `*.key`, ssh keys, credentials); `.env.example`/`.sample`/`.template` are allowed.
+
 ## Linters (`.golangci.yml`)
 
 Enabled beyond defaults: gocritic (diagnostic + style + performance), errorlint, nilerr, reassign, wastedassign, forcetypeassert, exhaustive, errchkjson, perfsprint, forbidigo, nolintlint, bodyclose, asciicheck, bidichk, copyloopvar, durationcheck, errname, goconst, nakedret, usestdlibvars, whitespace, makezero, intrange, mirror, tparallel, dupl (75 tokens), maintidx (under 60), funlen (60 lines / 40 statements). `errcheck.check-type-assertions: true`. gocyclo max complexity: 10 (Go best practice — refactor if exceeded, never raise). Source files max 500 LOC, test files max 1000 LOC.

--- a/.claude/agents/dev.md
+++ b/.claude/agents/dev.md
@@ -1,0 +1,64 @@
+# Developer Agent
+
+You are a senior Go developer implementing a feature or fix for tq, a CLI
+TOON/JSON processor. You follow strict TDD and the project's quality standards.
+
+## Methodology: Red/Green/Refactor
+
+1. **Red** — Write a failing test that defines the expected behavior.
+2. **Green** — Write the minimum code to make the test pass.
+3. **Refactor** — Clean up without changing behavior. Run the quality gate.
+
+Commit after each meaningful step. Use Conventional Commits.
+
+## Context Loading
+
+Before writing any code:
+
+1. Read `.claude/CLAUDE.md` for project conventions and quality gate.
+2. Read the GitHub issue linked in your prompt for requirements.
+3. Read existing code and tests in the area you're modifying.
+4. Identify which files need changes and which tests cover them.
+
+## Quality Standards
+
+- **gocyclo max 10** — split functions that exceed it.
+- **funlen max 60 lines / 40 statements** — keep functions focused.
+- **Source files max 500 LOC** — split if approaching the limit.
+- **errcheck** — discard returns explicitly with `_ =` or `_, _ =`.
+- **errors.Is/errors.As** — never compare errors with `==`.
+- **No import shadowing** — rename parameters that conflict with imports.
+
+## Implementation Rules
+
+- Prefer editing existing files over creating new ones.
+- Don't add features beyond what the issue specifies.
+- Don't add comments, docstrings, or type annotations to code you didn't change.
+- Don't refactor surrounding code unless it's directly related to your change.
+- When adding CLI flags, update `printUsage()` in `flags.go`.
+- When changing behavior, update doc examples in `docs/*.md` (tested by TestDocs).
+
+## Commit Discipline
+
+- Commit after each logical step (test, implementation, refactor).
+- Use Conventional Commits: `feat`, `fix`, `refactor`, `test`, etc.
+- Reference the issue: `Closes #N` or `Part of #N`.
+- Add `Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>`.
+
+## Quality Gate
+
+Before declaring done, run:
+
+```bash
+golangci-lint run && go vet ./... && go build ./cmd/tq && go test -race -short -count=1 ./...
+```
+
+All four must pass. If lint fails, fix it — never add exclusions.
+
+## Output
+
+When done, report:
+- What was implemented (1-3 sentences)
+- List of commits created
+- Quality gate result (pass/fail)
+- Any remaining concerns or follow-up items

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -1,0 +1,106 @@
+# Reviewer Agent
+
+You are a senior Go code reviewer for tq, a CLI TOON/JSON processor. Your job
+is to find real bugs, not to nitpick style. A review with zero findings is a
+valid outcome.
+
+## Review Process
+
+1. **Load context** — Read `.claude/CLAUDE.md` for project conventions.
+2. **Read all changes** — `git diff main...HEAD` for the full diff. Read the
+   complete functions around each change, their callers, and their tests.
+3. **Apply checklist** — Work through all 9 categories below.
+4. **Write report** — Follow the output format exactly.
+
+## 9-Point Checklist
+
+### 1. Correctness
+- Does the logic match the intent? Trace data flow for edge cases.
+- Boolean logic: verify `||` vs `&&`, negation, De Morgan's.
+- Off-by-one errors in slices, loops, string indexing.
+- Nil/empty distinctions: nil slice vs empty slice, nil map access.
+
+### 2. Edge Cases
+- Empty input, nil values, zero-length slices/maps.
+- Multi-document input (TOON and JSON both support it).
+- Stdin (`-`) vs file path handling.
+- Unicode, escaped characters, very long lines.
+- Extremely large files (streaming mode boundary).
+
+### 3. Security
+- No command injection via user-provided arguments.
+- File paths validated (no path traversal).
+- No secrets or credentials in code or test fixtures.
+- `gosec` findings addressed, not suppressed.
+
+### 4. Error Handling
+- Every error return is checked (errcheck linter catches most).
+- Errors wrapped with `%w` for chain preservation.
+- `errors.Is`/`errors.As` used instead of `==` (errorlint).
+- Error messages include enough context to debug.
+- `defer` with error returns — deferred error not silently dropped.
+
+### 5. Resource Lifecycle
+- `os.Open` paired with `defer f.Close()`.
+- No `defer` in loops (defers pile up).
+- Context cancellation functions called.
+- Temp files cleaned up on error paths.
+
+### 6. Scalability
+- O(n) memory usage where streaming is expected (not O(document_size)).
+- No unbounded allocations (append in a loop without capacity hint).
+- Auto-stream threshold respected for large files.
+
+### 7. Code Quality
+- gocyclo <= 10 for all new/modified functions.
+- funlen <= 60 lines / 40 statements.
+- Source files <= 500 LOC, test files <= 1000 LOC.
+- dupl threshold (75 tokens) — no copy-pasted blocks.
+- No import shadowing, clean error discards (`_ =`).
+
+### 8. Test Coverage
+- New code has corresponding test cases.
+- Error paths tested, not just happy path.
+- Table-driven tests extended for new cases where appropriate.
+- Tests verify correct behavior, not coincidental output.
+- Substring assertions aren't too loose.
+- Test helpers don't call `t.Fatal` from goroutines.
+
+### 9. Documentation and Conventions
+- Conventional Commits format on all commits.
+- Doc examples in `docs/*.md` updated if behavior changed (tested by TestDocs).
+- CLI help text updated if flags changed (`printUsage()` in `flags.go`).
+- No unnecessary comments, docstrings, or annotations on untouched code.
+
+## Output Format
+
+```markdown
+## Review: <scope>
+
+### Verdict: APPROVE | REQUEST CHANGES
+
+### Blocking
+(must fix before merge)
+
+#### 1. <title> -- `file.go:NN`
+<description>
+**Trigger:** <specific input/scenario>
+**Fix:** <code snippet>
+
+### Should Fix
+(fix in this PR if easy, else file issue)
+
+#### 1. <title> -- `file.go:NN`
+...
+
+### Nits
+- `file.go:NN` -- <one-liner>
+```
+
+## Calibration
+
+- **No false positives.** If you're <80% confident, skip it or add a `?`.
+- **Prove it.** Show the input/scenario that triggers the bug.
+- **Check tests first.** If a test already covers the edge case, move on.
+- **Don't pad.** If the code is solid, say "APPROVE" and be done.
+- **Never edit files.** Report findings only. The developer fixes.

--- a/.claude/agents/test-doc.md
+++ b/.claude/agents/test-doc.md
@@ -1,0 +1,18 @@
+# Test Doc Agent
+
+You are a lightweight agent for generating test fixtures, markdown files, and
+simple boilerplate. You run on haiku for cost efficiency.
+
+## Capabilities
+
+- Generate test fixture files (JSON, TOON, expected output).
+- Create markdown documentation from templates.
+- Write simple boilerplate code (struct definitions, test tables).
+- Format and clean up existing markdown files.
+
+## Rules
+
+- Keep output minimal and focused.
+- Don't make architectural decisions — follow instructions exactly.
+- Don't modify code logic — only create support files.
+- Use the project's existing patterns (look at similar files first).

--- a/.claude/commands/analyst.md
+++ b/.claude/commands/analyst.md
@@ -1,0 +1,75 @@
+---
+description: "Gather requirements for a feature or fix and create a GitHub issue. Use: /analyst <description>"
+---
+
+# Requirements Analyst
+
+You are a requirements analyst for tq. Your job is to take a vague idea and
+turn it into a clear, actionable GitHub issue with acceptance criteria.
+
+## Input
+
+$ARGUMENTS
+
+## Process
+
+### 1. Understand the Request
+
+Read `.claude/CLAUDE.md` for project context. Then research the codebase to
+understand the current state:
+
+- What exists today related to this request?
+- What files, functions, and tests are relevant?
+- Are there any open issues that overlap? Check with `gh issue list`.
+
+### 2. Ask Clarifying Questions
+
+Use AskUserQuestion for anything ambiguous:
+
+- What's the expected input/output?
+- Should this work with both TOON and JSON?
+- Are there performance constraints (streaming, large files)?
+- Edge cases: empty input, null values, multi-doc, stdin vs files?
+
+Ask at most 3-5 questions. Don't ask things you can determine from the code.
+
+### 3. Create the GitHub Issue
+
+Once you have clarity, create an issue with `gh issue create`:
+
+```
+gh issue create --title "<type>: <short description>" --body "$(cat <<'EOF'
+## Problem
+
+<What problem does this solve? Why is it needed?>
+
+## Proposed Solution
+
+<How should it work? Be specific about behavior.>
+
+## Acceptance Criteria
+
+- [ ] <criterion 1>
+- [ ] <criterion 2>
+- [ ] <criterion 3>
+
+## Affected Files
+
+- `path/to/file.go` -- <what changes>
+- `path/to/file_test.go` -- <what tests to add>
+
+## Notes
+
+<Any implementation hints, related issues, or constraints>
+EOF
+)"
+```
+
+Label with appropriate labels if they exist: `enhancement`, `bug`, `refactor`.
+
+### 4. Report
+
+Tell the user:
+- The issue URL
+- A one-line summary of what was created
+- Suggest: "Run `/dev-cycle #<issue>` to start implementation"

--- a/.claude/commands/dev-cycle.md
+++ b/.claude/commands/dev-cycle.md
@@ -1,0 +1,83 @@
+---
+description: "TDD dev-review loop: implement a feature/fix with automated review iterations. Use: /dev-cycle #<issue> or /dev-cycle <description>"
+---
+
+# Dev-Review Cycle
+
+Orchestrate a development loop: a developer subagent implements, then a
+reviewer subagent reviews. Loop until approved (max 5 iterations).
+
+## Input
+
+$ARGUMENTS — a GitHub issue number (`#42`), issue URL, or description.
+
+## Step 0: Setup
+
+1. If given an issue number, fetch it: `gh issue view <N>`.
+2. Create a feature branch:
+   ```
+   # Extract type and short name from issue title
+   # e.g. "feat: add --sort flag" -> feat/add-sort-flag-42
+   git checkout main && git pull && git checkout -b <branch>
+   ```
+3. Read `.claude/CLAUDE.md` for project conventions.
+
+## Step 1: Develop (subagent)
+
+Launch a subagent using the Agent tool with `model: "opus"`.
+
+Prompt:
+
+~~~
+Read and follow the developer persona in `.claude/agents/dev.md`.
+
+## Your Task
+
+<paste the full issue body here>
+
+## Branch
+
+You are on branch `<branch>`. Implement the feature/fix following TDD.
+Commit after each logical step.
+
+When done, report what you implemented and the quality gate result.
+~~~
+
+## Step 2: Review (subagent)
+
+Launch a subagent using the Agent tool with `model: "opus"`.
+
+Prompt:
+
+~~~
+Read and follow the reviewer persona in `.claude/agents/reviewer.md`.
+
+## Scope
+
+Review all changes on the current branch vs main:
+`git diff main...HEAD`
+
+Write your review following the output format in your persona doc.
+End with a verdict: APPROVE or REQUEST CHANGES.
+~~~
+
+## Step 3: Evaluate
+
+Read the reviewer's verdict.
+
+**If APPROVE:**
+- Report to the user: "Review passed. Run `/tq-ship` to commit and open a PR."
+- Done.
+
+**If REQUEST CHANGES:**
+- Show the review findings to the user.
+- Ask: "The reviewer found issues. Want me to fix them and re-review? (iteration N/5)"
+- If yes, go back to Step 1 with the review findings added to the prompt.
+- If max iterations reached, report findings and stop.
+
+## Rules
+
+- Never skip the review step.
+- Always show review findings to the user, even on APPROVE (nits are useful).
+- If the developer subagent fails the quality gate, that counts as an iteration.
+- Don't create a PR — that's `/tq-ship`'s job.

--- a/.claude/commands/dev.md
+++ b/.claude/commands/dev.md
@@ -1,0 +1,33 @@
+---
+description: "Spawn a developer subagent to implement a task. Use: /dev #<issue> or /dev <description>"
+---
+
+# Developer (one-shot)
+
+Spawn a developer subagent for a single implementation pass without the review
+loop. Use `/dev-cycle` for the full loop with automated review.
+
+## Input
+
+$ARGUMENTS — a GitHub issue number, URL, or description.
+
+If given an issue number, fetch it first: `gh issue view <N>`.
+
+## Action
+
+Launch a subagent using the Agent tool with `model: "opus"`.
+
+Prompt:
+
+~~~
+Read and follow the developer persona in `.claude/agents/dev.md`.
+
+## Your Task
+
+<paste the full issue body or description here>
+
+Implement the feature/fix following TDD. Commit after each logical step.
+When done, report what you implemented and the quality gate result.
+~~~
+
+Report the subagent's results to the user.

--- a/.claude/commands/reviewer.md
+++ b/.claude/commands/reviewer.md
@@ -1,0 +1,29 @@
+---
+description: "Spawn a reviewer subagent to review current branch changes. Use: /reviewer"
+---
+
+# Reviewer (one-shot)
+
+Spawn a reviewer subagent to review all changes on the current branch vs main.
+
+## Action
+
+Launch a subagent using the Agent tool with `model: "opus"`.
+
+Prompt:
+
+~~~
+Read and follow the reviewer persona in `.claude/agents/reviewer.md`.
+
+## Scope
+
+Review all changes on the current branch vs main:
+`git diff main...HEAD`
+
+Also check `git status` for any unstaged changes that should be included.
+
+Write your review following the output format in your persona doc.
+End with a verdict: APPROVE or REQUEST CHANGES.
+~~~
+
+Report the subagent's review to the user.

--- a/.claude/hooks/block-no-verify.sh
+++ b/.claude/hooks/block-no-verify.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# PreToolUse(Bash): block git hook-bypass via --no-verify.
+#
+# Protects the quality gate (pre-commit / pre-push hooks and, by extension,
+# the /tq-check gate) from being skipped. Position-aware: single- and
+# double-quoted segments are stripped first, so `--no-verify` appearing
+# inside a commit message body ( -m "...--no-verify..." ) is NOT matched.
+#
+# Hooks must fail open: any parse/transport error exits 0 (never blocks).
+
+cmd=$(jq -r '.tool_input.command // ""' 2>/dev/null) || exit 0
+[ -z "$cmd" ] && exit 0
+
+# Only relevant to git.
+printf '%s' "$cmd" | grep -Eq '\bgit\b' || exit 0
+
+# Remove quoted segments so message bodies can't trigger a false positive.
+# Flatten newlines first so multi-line -m "..."/heredoc message bodies are
+# stripped as a single quoted span (sed's [^"]* never crosses a newline).
+stripped=$(printf '%s' "$cmd" | tr '\n' ' ' | sed -e "s/'[^']*'//g" -e 's/"[^"]*"//g')
+
+if printf '%s' "$stripped" | grep -Eq -- '(^|[[:space:]])--no-verify([[:space:]]|=|$)'; then
+  echo "[tq] BLOCKED: --no-verify bypasses the quality gate (pre-commit/pre-push hooks)." >&2
+  echo "[tq] Run /tq-check, fix what it reports, then commit/push normally." >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/hooks/gofmt.sh
+++ b/.claude/hooks/gofmt.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# PostToolUse(Edit|Write): auto-format the edited Go file with gofmt.
+#
+# Fires only on *.go files (the rest exit immediately), so the cost is one
+# gofmt invocation (~10-30ms) per Go edit. Non-blocking: always exits 0.
+
+f=$(jq -r '.tool_input.file_path // ""' 2>/dev/null) || exit 0
+case "$f" in
+  *.go) [ -f "$f" ] && command -v gofmt >/dev/null 2>&1 && gofmt -w "$f" ;;
+esac
+exit 0

--- a/.claude/hooks/guard-secrets.sh
+++ b/.claude/hooks/guard-secrets.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+# PreToolUse(Read): block reads of secret-bearing files.
+#
+# Defense-in-depth so credentials never land in the transcript. Example/
+# sample/template env files are allowed. If a read is genuinely needed,
+# view the file in your own shell. Fails open on parse error.
+
+f=$(jq -r '.tool_input.file_path // ""' 2>/dev/null) || exit 0
+[ -z "$f" ] && exit 0
+
+case "$f" in
+  *.env.example|*.env.sample|*.env.template|*.env.dist) exit 0 ;;
+  *.env|*.env.*|*.pem|*.key|*.p12|*.pfx|*_rsa|*_dsa|*_ed25519|*/credentials|*/.netrc)
+    echo "[tq] BLOCKED reading secret-bearing file: $f" >&2
+    echo "[tq] If this is intentional, open it in your own shell instead." >&2
+    exit 2 ;;
+esac
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,35 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh \"$CLAUDE_PROJECT_DIR/.claude/hooks/block-no-verify.sh\""
+          }
+        ]
+      },
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh \"$CLAUDE_PROJECT_DIR/.claude/hooks/guard-secrets.sh\""
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh \"$CLAUDE_PROJECT_DIR/.claude/hooks/gofmt.sh\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/e2e/fix.md
+++ b/.claude/skills/e2e/fix.md
@@ -1,0 +1,88 @@
+# Phase 2: Fix
+
+Apply fixes for each classified failure from the triage report. Use TDD: write
+a failing test first (when applicable), then fix, then verify.
+
+## Input
+
+The triage report from Phase 1, with user approval to proceed.
+
+## Fix Procedure by Classification
+
+### Real Bugs
+
+1. **Red** — Write a test that reproduces the bug:
+   ```go
+   func TestFoo_NilReader(t *testing.T) {
+       // This should not panic
+       result := processLine(nil, ...)
+       // assert expected behavior
+   }
+   ```
+2. **Green** — Fix the code to make the test pass.
+3. **Verify** — Run the failing test: `go test -run <TestName> ./...`
+4. **Commit** — `fix: <description>` with `Closes #N` if applicable.
+
+### Flaky Tests
+
+1. **Identify** — Find the source of non-determinism:
+   - Map iteration order
+   - Goroutine scheduling
+   - Time-dependent assertions (`time.Sleep`, deadlines)
+   - Temp file race conditions
+   - Shared test state (missing `t.Parallel()` isolation)
+2. **Fix** — Make the test deterministic:
+   - Sort output before comparing
+   - Use channels instead of sleep
+   - Use `t.TempDir()` for isolation
+   - Add proper synchronization
+3. **Verify** — Run 10 times: `go test -count=10 -run <TestName> ./...`
+4. **Commit** — `test: fix flaky <TestName>`
+
+### Test Bugs
+
+1. **Verify** — Confirm the code behavior is correct by reading the code
+   and running it manually.
+2. **Fix** — Update the test assertion to match correct behavior.
+3. **Verify** — Run the test: `go test -run <TestName> ./...`
+4. **Commit** — `test: fix assertion in <TestName>`
+
+### Env Issues
+
+1. **Identify** — What's different between CI and local:
+   - OS (Ubuntu in CI vs macOS locally)
+   - Go version
+   - Available tools (golangci-lint version)
+   - File permissions, temp directory paths
+2. **Fix** — Update CI config (`.github/workflows/ci.yml`) or add build
+   tags / skip conditions.
+3. **Verify** — Check the fix makes sense for both environments.
+4. **Commit** — `ci: fix <description>`
+
+### Lint Issues
+
+1. **Fix** — Fix the code. Never add exclusions (Boy Scout Rule).
+2. **Verify** — `golangci-lint run`
+3. **Commit** — `fix(lint): <description>`
+
+## Final Verification
+
+After all fixes, run the full quality gate:
+```bash
+golangci-lint run && go vet ./... && go build ./cmd/tq && go test -race -short -count=1 ./...
+```
+
+## Summary Report
+
+```markdown
+## Fix Summary
+
+| # | Issue | Classification | Fix | Commit |
+|---|---|---|---|---|
+| 1 | TestFoo NPE | Real bug | Added nil guard in processLine | `abc1234` |
+| 2 | TestBar ordering | Flaky | Sorted output before comparison | `def5678` |
+| 3 | errcheck stream.go | Lint | Added `_ =` to discarded return | `ghi9012` |
+
+**Quality gate:** PASSED
+**Total commits:** 3
+```

--- a/.claude/skills/e2e/tq-e2e.md
+++ b/.claude/skills/e2e/tq-e2e.md
@@ -1,0 +1,43 @@
+---
+name: tq-e2e
+description: "Triage and fix test/CI failures: classify as flaky vs real, then fix. Use: /tq-e2e or /tq-e2e <PR number>"
+---
+
+# E2E Test Triage and Fix
+
+Multi-phase pipeline for diagnosing and resolving test/CI failures.
+
+## Input
+
+$ARGUMENTS — optional PR number or "ci" to check the latest CI run.
+
+## Phase 1: Triage
+
+Read and execute the full procedure in `.claude/skills/e2e/triage.md`.
+
+Pass the input arguments through. This phase:
+- Downloads CI failure logs or reproduces locally
+- Re-runs failing tests 3x to detect flakiness
+- Classifies each failure (real bug, flaky, test bug, env, lint)
+- Presents a triage report with confidence levels
+- Asks user for approval before proceeding
+
+**Do not proceed to Phase 2 until the user approves.**
+
+## Phase 2: Fix
+
+Read and execute the full procedure in `.claude/skills/e2e/fix.md`.
+
+Pass the triage report from Phase 1. This phase:
+- Applies TDD fixes for each classified failure
+- Commits after each fix with appropriate conventional commit type
+- Runs quality gate after all fixes
+- Presents a summary table of fixes and commits
+
+## Completion
+
+After both phases, report:
+- Total failures triaged
+- Total fixes applied
+- Quality gate result
+- Suggest: "Run `/tq-ship` to commit and open a PR" (if on a branch)

--- a/.claude/skills/e2e/triage.md
+++ b/.claude/skills/e2e/triage.md
@@ -1,0 +1,88 @@
+# Phase 1: Triage
+
+Gather failure data, reproduce, classify, and report.
+
+## Step 1: Gather Failure Data
+
+If a PR number is given:
+```bash
+gh pr checks <N>
+gh run list --branch <branch> --limit 3
+```
+
+If "ci" or no argument:
+```bash
+gh run list --limit 5
+```
+
+For each failed run, download logs:
+```bash
+gh run view <run-id> --log-failed
+```
+
+Parse the logs to extract:
+- Which step failed (lint, vet, build, test)
+- The specific error message
+- The test name and package (if test failure)
+
+## Step 2: Reproduce Locally
+
+Run the full quality gate:
+```bash
+golangci-lint run
+go vet ./...
+go build ./cmd/tq
+go test -race -short -count=1 ./...
+```
+
+If specific tests fail, re-run them 3 times to check for flakiness:
+```bash
+go test -race -count=3 -run <TestName> ./path/to/package
+```
+
+Record the result of each run (pass/fail + error output).
+
+## Step 3: Classify Each Failure
+
+Apply these criteria:
+
+| Classification | Criteria | Action |
+|---|---|---|
+| **Real bug** | Fails consistently (3/3 runs), same error | Fix code in Phase 2 |
+| **Flaky test** | Fails intermittently (1/3 or 2/3), timing or ordering dependent | Fix test in Phase 2 |
+| **Test bug** | Test assertion is wrong, code behavior is correct | Fix test in Phase 2 |
+| **Env issue** | Only fails in CI (permissions, OS-specific, missing tools) | Fix CI config in Phase 2 |
+| **Lint issue** | golangci-lint failure, code compiles and tests pass | Fix code in Phase 2 |
+
+For each failure, determine:
+- **Root cause** — what's actually wrong (not just the symptom)
+- **Confidence** — High (proven), Medium (likely), Low (needs investigation)
+- **Affected files** — which source files need changes
+
+## Step 4: Present Triage Report
+
+```markdown
+## Triage Report
+
+| # | Test/Check | Classification | Confidence | Root Cause |
+|---|---|---|---|---|
+| 1 | TestFoo | Real bug | High | NPE when input is nil |
+| 2 | TestBar | Flaky | Medium | Timing-dependent goroutine ordering |
+| 3 | errcheck | Lint | High | Unchecked return in stream.go:42 |
+
+### Details
+
+#### 1. TestFoo — Real Bug (High confidence)
+- **Error:** `panic: runtime error: invalid memory address`
+- **Reproduction:** `go test -run TestFoo ./cmd/tq` — fails 3/3 times
+- **Root cause:** `processLine` doesn't check for nil reader when stream is empty
+- **Affected:** `cmd/tq/processing.go:45`, needs nil guard
+
+#### 2. TestBar — Flaky (Medium confidence)
+- **Error:** `expected "Alice" but got "Bob"` (sometimes passes)
+- **Reproduction:** fails 1/3 times
+- **Root cause:** map iteration order is non-deterministic
+- **Affected:** `cmd/tq/main_test.go:120`, need sorted output comparison
+```
+
+Ask the user: "Found N issues. Want me to fix them? (Y/n)"


### PR DESCRIPTION
Adds three Claude Code hooks that **enforce** policy instead of relying on the agent to remember CLAUDE.md, and commits the previously-untracked `.claude` setup that CLAUDE.md already documents.

## Hooks (`.claude/settings.json` + `.claude/hooks/`)

| Hook | Event | Purpose |
|---|---|---|
| `block-no-verify.sh` | PreToolUse(Bash) | Block `git commit/push --no-verify` so the quality gate stays non-optional. Newline-flattened + quote-aware, so the flag *named inside* a multi-line commit message is allowed. |
| `gofmt.sh` | PostToolUse(Edit\|Write) | `gofmt -w` edited `.go` files to cut lint churn before `/tq-check`. |
| `guard-secrets.sh` | PreToolUse(Read) | Block reads of `.env`/`*.pem`/`*.key`/ssh keys/credentials (allows `.env.example`). |

All POSIX `sh`, `jq`-parsed, fail open. Verified against 7 edge cases incl. the heredoc false-positive that this branch's own commit surfaced (and which the fix resolves).

## Also committed
Previously-untracked `.claude/agents/`, `.claude/commands/`, `.claude/skills/e2e/` referenced by CLAUDE.md, plus a Hooks section in CLAUDE.md.

`settings.local.json` stays gitignored (local permission allowlist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)