### PR TITLE
ci: pin golangci-lint to v2.12.2 (stop using latest)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,10 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9
         with:
-          version: latest
+          # Pinned, not `latest`: a silent golangci-lint upgrade (v2.12.2 began
+          # counting test-file occurrences toward goconst) broke main on a
+          # routine Dependabot PR. Bump this deliberately, not implicitly.
+          version: v2.12.2
 
   cross-platform-smoke:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Why

CI ran `golangci-lint-action` with `version: latest`, so it silently adopted whatever golangci-lint published. **v2.12.2** changed `goconst` to count `_test.go` occurrences toward its threshold, which pushed `--arg` over the limit and broke the `lint` job **on main** — surfacing on an unrelated Dependabot PR (root-caused and fixed in #82).

This is exactly the failure mode that earlier today blocked every open Dependabot PR.

## Change

Pin `version: v2.12.2` (the version main currently passes). Linter upgrades become a deliberate, reviewed bump instead of an implicit one that fails on a random PR.

The action itself stays SHA-pinned and Dependabot-managed; only the golangci-lint *binary* is pinned here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)