### PR TITLE
docs: explain why brews + app-id deprecations are kept

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,10 @@ jobs:
         id: homebrew_tap_app_token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
+          # `app-id` is deprecated in favor of `client-id`, but kept on purpose:
+          # client-id expects the App's Client ID (a different value than the
+          # numeric App ID stored in this secret), so switching needs a new
+          # secret. app-id still works; the deprecation warning is harmless.
           app-id: ${{ secrets.HOMEBREW_TAP_APP_ID }}
           private-key: ${{ secrets.HOMEBREW_TAP_APP_PRIVATE_KEY }}
           owner: tq-lang

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -33,6 +33,10 @@ release:
   footer: |
     **Full Changelog**: https://github.com/tq-lang/tq/blob/main/CHANGELOG.md
 
+# NOTE: `brews` is deprecated in favor of `homebrew_casks`, but we keep it
+# deliberately. Homebrew Casks are macOS-only; this formula's on_linux blocks
+# keep `brew install` working on Linux too. Revisit only if goreleaser removes
+# `brews` outright (then Linux users move to the release tarballs).
 brews:
   - repository:
       owner: tq-lang


### PR DESCRIPTION
Follow-up to the v0.1.0 release, which surfaced two goreleaser/Actions deprecation warnings. Investigated both — neither should be "fixed" by migrating:

- **goreleaser `brews` → `homebrew_casks`**: Casks are **macOS-only**. The formula's `on_linux` blocks keep `brew install` working on Linux, which a cask would drop. goreleaser has no Linux-Homebrew alternative to `brews`.
- **`create-github-app-token` `app-id` → `client-id`**: `client-id` expects the App's **Client ID** string — a different value than the numeric App ID in `secrets.HOMEBREW_TAP_APP_ID`. Switching needs a new secret; `app-id` still works.

Both still function on the pinned goreleaser `~> v2`. This PR just adds inline comments recording the rationale so the warnings aren't re-investigated each release. **No behavior change.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)